### PR TITLE
Update configs/templates/hpc-stack-dev/spack.yaml to avoid duplicates

### DIFF
--- a/configs/templates/hpc-stack-dev/spack.yaml
+++ b/configs/templates/hpc-stack-dev/spack.yaml
@@ -27,7 +27,7 @@ spack:
       version: [11.5.0]
       variants: +python
     cmake:
-      version: [3.20.1]
+      version: [3.22.1]
     crtm:
       version: [2.4.0]
     ecbuild:
@@ -221,9 +221,9 @@ spack:
       - gsi-env@hpc-stack-dev ^zlib@1.2.11
       - ufs-utils-env@hpc-stack-dev ^zlib@1.2.11
       - nceplibs-env@hpc-stack-dev ^zlib@1.2.11
-      - soca-env@hpc-stack-dev ^zlib@1.2.11
+      #- soca-env@hpc-stack-dev ^zlib@1.2.11
       - base-env@hpc-stack-dev ^zlib@1.2.11
-      - jedi-base-env@hpc-stack-dev ^zlib@1.2.11
+      #- jedi-base-env@hpc-stack-dev ^zlib@1.2.11
 
   specs:
     - matrix:

--- a/configs/templates/hpc-stack-dev/spack.yaml
+++ b/configs/templates/hpc-stack-dev/spack.yaml
@@ -213,17 +213,15 @@ spack:
   # Set compilers here
   - compilers: ['%intel']
   - packages:
-      - global-workflow-env@hpc-stack-dev ^zlib@1.2.11
-      - ufs-weather-model-env~debug@hpc-stack-dev ^zlib@1.2.11
-      - ufs-weather-model-env+debug@hpc-stack-dev ^zlib@1.2.11 
-      - upp-env@hpc-stack-dev ^zlib@1.2.11
-      - ww3-env@hpc-stack-dev ^zlib@1.2.11
-      - gsi-env@hpc-stack-dev ^zlib@1.2.11
-      - ufs-utils-env@hpc-stack-dev ^zlib@1.2.11
-      - nceplibs-env@hpc-stack-dev ^zlib@1.2.11
-      #- soca-env@hpc-stack-dev ^zlib@1.2.11
-      - base-env@hpc-stack-dev ^zlib@1.2.11
-      #- jedi-base-env@hpc-stack-dev ^zlib@1.2.11
+      - global-workflow-env@hpc-stack-dev ^zlib@1.2.11 ^cmake@3.22.1 ^py-setuptools@63.0.0
+      - ufs-weather-model-env~debug@hpc-stack-dev ^zlib@1.2.11 ^cmake@3.22.1 ^py-setuptools@63.0.0
+      - ufs-weather-model-env+debug@hpc-stack-dev ^zlib@1.2.11 ^cmake@3.22.1 ^py-setuptools@63.0.0
+      - upp-env@hpc-stack-dev ^zlib@1.2.11 ^cmake@3.22.1 ^py-setuptools@63.0.0
+      - ww3-env@hpc-stack-dev ^zlib@1.2.11 ^cmake@3.22.1 ^py-setuptools@63.0.0
+      - gsi-env@hpc-stack-dev ^zlib@1.2.11 ^cmake@3.22.1 ^py-setuptools@63.0.0
+      - ufs-utils-env@hpc-stack-dev ^zlib@1.2.11 ^cmake@3.22.1 ^py-setuptools@63.0.0
+      - nceplibs-env@hpc-stack-dev ^zlib@1.2.11 ^cmake@3.22.1 ^py-setuptools@63.0.0
+      - soca-env@hpc-stack-dev ^zlib@1.2.11 ^cmake@3.22.1 ^py-setuptools@63.0.0
 
   specs:
     - matrix:


### PR DESCRIPTION
@AlexanderRichert-NOAA Please merge this into your branch. For now, we need to remove the JEDI packages from the hpc-stack-dev transition environment to avoid duplicates. This is just for the release tag, we can figure out why duplicates are created later and fix it on develop.

I installed the hpc-stack-dev environment with this template on Hera using Intel, unfortunately the system is under maintenance now. But I'll go back and finish up the modules etc once it comes back online, and I'll also provide you and @hanglei-noaa with instructions on how to do the same with GNU.