### PR TITLE
WIP: run one UFS WM test

### DIFF
--- a/util/weekly_build/06_AppTests.sh
+++ b/util/weekly_build/06_AppTests.sh
@@ -4,6 +4,21 @@ set -ex
 
 if [ -z $SETUPDONE ]; then . ShellSetup.sh $* ; fi
 
+cd $RUNDIR/$RUNID
+
+set +x
+. setup.sh
+set -x
+
+for compiler in $COMPILERS; do
+  cd $RUNDIR/$RUNID/envs/build-${compiler/@/-}
+  spack env activate .
+  spack module lmod refresh -y
+  spack stack setup-meta-modules
+done
+
+# TODO: test against all compilers
+# For now, only Intel (see apptests/test_ufswm.sh)
 if [ "$TEST_UFSWM" == ON ]; then
   ./apptests/test_ufswm.sh
 fi

--- a/util/weekly_build/06_AppTests.sh
+++ b/util/weekly_build/06_AppTests.sh
@@ -16,5 +16,5 @@ for compiler in $COMPILERS; do
 done
 
 if [ "$TEST_UFSWM" == ON ]; then
-  ./apptests/test_ufswm.sh $*
+  ./apptests/test_ufswm.sh
 fi

--- a/util/weekly_build/06_AppTests.sh
+++ b/util/weekly_build/06_AppTests.sh
@@ -2,8 +2,6 @@
 
 set -ex
 
-if [ -z $SETUPDONE ]; then . ShellSetup.sh $* ; fi
-
 cd $RUNDIR/$RUNID
 
 set +x
@@ -17,8 +15,6 @@ for compiler in $COMPILERS; do
   spack stack setup-meta-modules
 done
 
-# TODO: test against all compilers
-# For now, only Intel (see apptests/test_ufswm.sh)
 if [ "$TEST_UFSWM" == ON ]; then
-  ./apptests/test_ufswm.sh
+  ./apptests/test_ufswm.sh $*
 fi

--- a/util/weekly_build/apptests/test_ufswm.sh
+++ b/util/weekly_build/apptests/test_ufswm.sh
@@ -10,11 +10,12 @@ cd ${RUNDIR}
 UFSWM_BRANCH=${UFSWM_BRANCH:-develop}
 UFSWM_URL=${UFSWM_URL:-"https://github.com/ufs-community/ufs-weather-model.git"}
 
-git clone -b ${BRANCH} --single-branch --recurse-submodules ${UFSWM_URL}
+git clone --single-branch --recurse-submodules ${UFSWM_URL} -b ${UFSWM_BRANCH}
 cd ufs-weather-model/tests
 
 # rt.sh will parse arguments passed to it
-./rt.sh  "${@}"
+RT_ARGS=${RT_ARGS:-"-a ${BATCHACCOUNT:?} -n 'control_c48 intel'"}
+./rt.sh $RT_ARGS
 
 rc = $?
 return rc

--- a/util/weekly_build/apptests/test_ufswm.sh
+++ b/util/weekly_build/apptests/test_ufswm.sh
@@ -4,17 +4,17 @@
 # tested (ideally, have a discernably different error condition if there are
 # numerical differences)
 
+echo Base directory: ${RUNDIR:?}
 cd ${RUNDIR}
 
-# The following need to be cleaned up for proper variable substitution; this is a one-off test
-BRANCH=spack-stack-automation
+UFSWM_BRANCH=${UFSWM_BRANCH:-develop}
+UFSWM_URL=${UFSWM_URL:-"https://github.com/ufs-community/ufs-weather-model.git"}
 
-git clone -b ${BRANCH} --single-branch --recurse-submodules https://github.com/rickgrubin-noaa/ufs-weather-model.git
+git clone -b ${BRANCH} --single-branch --recurse-submodules ${UFSWM_URL}
 cd ufs-weather-model/tests
 
-# -r ==> rocoto ; not strictly necessary, can run without
-./rt.sh -a epic -k -r -n "control_c48 intel"
+# rt.sh will parse arguments passed to it
+./rt.sh  "${@}"
 
 rc = $?
 return rc
-

--- a/util/weekly_build/apptests/test_ufswm.sh
+++ b/util/weekly_build/apptests/test_ufswm.sh
@@ -3,3 +3,18 @@
 # Do some stuff, and exit non-zero if UFSWM cannot be successfully built and
 # tested (ideally, have a discernably different error condition if there are
 # numerical differences)
+
+cd ${RUNDIR}
+
+# The following need to be cleaned up for proper variable substitution; this is a one-off test
+BRANCH=spack-stack-automation
+
+git clone -b ${BRANCH} --single-branch --recurse-submodules https://github.com/rickgrubin-noaa/ufs-weather-model.git
+cd ufs-weather-model/tests
+
+# -r ==> rocoto ; not strictly necessary, can run without
+./rt.sh -a epic -k -r -n "control_c48 intel"
+
+rc = $?
+return rc
+

--- a/util/weekly_build/sites/orion.sh
+++ b/util/weekly_build/sites/orion.sh
@@ -1,0 +1,29 @@
+
+COMPILERS=${COMPILERS:-"intel"}
+TEMPLATES=${TEMPLATES:-"unified-dev"}
+
+function alert_cmd {
+  mail -s 'spack-stack weekly build failure' richard.grubin@noaa.gov < <(echo "Weekly spack-stack build failed in $1. Run ID: $RUNID")
+}
+
+module --force purge
+umask 0022
+
+SPACK_STACK_URL=https://github.com/JCSDA/spack-stack.git
+SPACK_STACK_BRANCH=develop
+
+KEEP_WEEKLY_BUILD_DIR="YES"
+PADDED_LENGTH=200
+
+# package test / install settings (future use)
+# PACKAGES_TO_TEST="libpng libaec jasper w3emc g2c"
+# PACKAGES_TO_INSTALL="ufs-weather-model-env"
+
+TEST_UFSWM=ON
+UFSWM_BRANCH=develop
+UFSWM_URL="https://github.com/ufs-community/ufs-weather-model.git"
+
+# rt.sh parameters / arguments
+BATCHACCOUNT=epic
+RT_ARGS="-a ${BATCHACCOUNT} -k -r -n 'control_c48 intel'"
+


### PR DESCRIPTION
### Summary

Add testing for one `UFS WM` test.

### Testing

**Orion**

- compiler: `Intel`
- tool: `Jenkins` pipeline
- test results (must have `epic` role account access):
  - UFS WM run dir:
    - `/work/noaa/epic/role-epic/jenkins/workspace/spack-stack/ufs/Orion/stmp/role-epic/stmp/role-epic/FV3_RT/rt_2528430`
      - `control_c48_intel.log` (single test result)
  - Single test logs:
    - `/work/noaa/epic/role-epic/jenkins/workspace/spack-stack/ufs/Orion/ufs-weather-model/tests/logs`
      - `RegressionTests_orion.log` (regression tests)

### Applications affected

n/a

### Systems affected

n/a

### Dependencies

Utilizes  [UFS WM @ spack-stack-automation](https://github.com/rickgrubin-noaa/ufs-weather-model/tree/spack-stack-automation)

### Issue(s) addressed

Completes [pr/1213](https://github.com/JCSDA/spack-stack/pull/1213)

### Checklist
- [ ] This PR addresses one issue/problem/enhancement, or has a very good reason for not doing so.
- [ ] These changes have been tested on the affected systems and applications.
- [ ] All dependency PRs/issues have been resolved and this PR can be merged.
